### PR TITLE
fix: phone icon missing sometimes

### DIFF
--- a/twilio_integration/boot.py
+++ b/twilio_integration/boot.py
@@ -1,0 +1,7 @@
+from __future__ import unicode_literals
+import frappe
+
+def boot_session(bootinfo):
+    """Include twilio enabled flag into boot.
+    """     
+    bootinfo.twilio_settings_enabled = frappe.db.get_single_value('Twilio Settings', 'enabled')

--- a/twilio_integration/hooks.py
+++ b/twilio_integration/hooks.py
@@ -139,3 +139,7 @@ doctype_js = {
 override_doctype_class = {
 	"Notification": "twilio_integration.overrides.notification.SendNotification"
 }
+
+# boot
+# ----------
+boot_session = "twilio_integration.boot.boot_session"

--- a/twilio_integration/public/js/twilio_call_handler.js
+++ b/twilio_integration/public/js/twilio_call_handler.js
@@ -171,11 +171,9 @@ var onload_script = function() {
 		}
 	}
 
-	frappe.db.get_single_value('Twilio Settings', 'enabled').then(is_integration_enabled => {
-		if (is_integration_enabled) {
-			frappe.phone_call.handler = (to_number, frm) => new TwilioCall(to_number, frm);
-		}
-	});
+	if (frappe.boot.twilio_settings_enabled){
+		frappe.phone_call.handler = (to_number, frm) => new TwilioCall(to_number, frm);
+	};
 }
 
 var script = document.createElement('script');


### PR DESCRIPTION
Phone handler is added to the frappe object through async call.
Phone icon is missing if phone handler check happens to be done before
async call is completed.

fix: Getting twilio enabled flag in client boot session instead API call.