### PR TITLE
fix: module import that causes app install issue

### DIFF
--- a/twilio_integration/__init__.py
+++ b/twilio_integration/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from .twilio_integration import api
 
 __version__ = '0.0.1'
 

--- a/twilio_integration/twilio_integration/__init__.py
+++ b/twilio_integration/twilio_integration/__init__.py
@@ -1,0 +1,1 @@
+from . import api


### PR DESCRIPTION
App installation is failing because of import call, that is happening before requirements installed. Moved the import into app package from higher level directory.