### PR TITLE
refactor: capture call log status & call direction

### DIFF
--- a/twilio_integration/__init__.py
+++ b/twilio_integration/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from .twilio_integration import api
 
 __version__ = '0.0.1'
 

--- a/twilio_integration/twilio_integration/__init__.py
+++ b/twilio_integration/twilio_integration/__init__.py
@@ -1,0 +1,1 @@
+from . import api

--- a/twilio_integration/twilio_integration/api.py
+++ b/twilio_integration/twilio_integration/api.py
@@ -1,6 +1,7 @@
 from werkzeug.wrappers import Response
 
 import frappe
+from frappe import _
 from frappe.contacts.doctype.contact.contact import get_contact_with_phone_number
 from .twilio_handler import Twilio, IncomingCall, TwilioCallDetails
 
@@ -83,7 +84,7 @@ def update_call_log(call_sid, status=None):
 
 	call_details = twilio.get_call_info(call_sid)
 	call_log = frappe.get_doc("Call Log", call_sid)
-	call_log.status = status or call_details.CallStatus.title()
+	call_log.status = status or TwilioCallDetails.get_call_status(call_details.status)
 	call_log.duration = call_details.duration
 	call_log.flags.ignore_permissions = True
 	call_log.save()
@@ -94,6 +95,7 @@ def update_recording_info(**kwargs):
 		args = frappe._dict(kwargs)
 		recording_url = args.RecordingUrl
 		call_sid = args.CallSid
+		update_call_log(call_sid)
 		frappe.db.set_value("Call Log", call_sid, "recording_url", recording_url)
 	except:
 		frappe.log_error(title=_("Failed to capture Twilio recording"))

--- a/twilio_integration/twilio_integration/twilio_handler.py
+++ b/twilio_integration/twilio_integration/twilio_handler.py
@@ -135,7 +135,7 @@ class TwilioCallDetails:
 		self.account_sid = call_info.get('AccountSid')
 		self.application_sid = call_info.get('ApplicationSid')
 		self.call_sid = call_info.get('CallSid')
-		self.call_status = call_info.get('CallStatus').title()
+		self.call_status = self.get_call_status(call_info.get('CallStatus'))
 		self._call_from = call_from
 		self._call_to = call_to
 
@@ -143,8 +143,8 @@ class TwilioCallDetails:
 		"""TODO: Check why Twilio gives always Direction as `inbound`?
 		"""
 		if self.call_info.get('Caller').lower().startswith('client'):
-			return 'Outbound'
-		return 'Inbound'
+			return 'Outgoing'
+		return 'Incoming'
 
 	def get_from_number(self):
 		return self._call_from or self.call_info.get('From')
@@ -152,9 +152,16 @@ class TwilioCallDetails:
 	def get_to_number(self):
 		return self._call_to or self.call_info.get('To')
 
+	@classmethod
+	def get_call_status(cls, twilio_status):
+		"""Convert Twilio given status into system status.
+		"""
+		twilio_status = twilio_status or ''
+		return ' '.join(twilio_status.split('-')).title()
+
 	def to_dict(self):
 		return {
-			'direction': self.get_direction(),
+			'type': self.get_direction(),
 			'status': self.call_status,
 			'id': self.call_sid,
 			'from': self.get_from_number(),


### PR DESCRIPTION
This is to be in sync with ERPNext call log changes: https://github.com/frappe/erpnext/pull/24485

As, CallLog doctype is modified to capture cal direction and some new statuses, call log creation and updation in twilio  is changed accordingly.