### PR TITLE
feat: Added dialpad to support Interactive Voice Response (IVR)

### DIFF
--- a/twilio_integration/hooks.py
+++ b/twilio_integration/hooks.py
@@ -23,7 +23,7 @@ fixtures = [{"dt": "Custom Field", "filters": [
 # ------------------
 
 # include js, css files in header of desk.html
-# app_include_css = "/assets/twilio_integration/css/twilio_integration.css"
+app_include_css = "/assets/twilio_integration/css/twilio_call_handler.css"
 app_include_js = "/assets/js/twilio-call-handler.js"
 
 # include js, css files in header of web template

--- a/twilio_integration/public/css/twilio_call_handler.css
+++ b/twilio_integration/public/css/twilio_call_handler.css
@@ -1,0 +1,67 @@
+.dialpad-section {
+	flex: 1;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	border-radius: var(--border-radius);
+	pointer-events: all;
+	position: absolute;
+	top: 140px;
+	right: 23px;
+	z-index: 2000;
+	border: 1px solid var(--gray-300);
+	box-shadow: var(--shadow-base);
+	background-color: white;
+}
+
+.dialpad-section .dialpad-container {
+	padding: var(--padding-sm);
+}
+
+.dialpad-section .dialpad-container .dialpad-keys {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dialpad-section .dialpad-container .dialpad-input {
+	border-radius: var(--border-radius);
+	background-color: var(--control-bg);
+	text-align: center !important;
+	height: calc(1.5em + 1rem + 1px);
+	margin-bottom: var(--margin-sm);
+	cursor: text;
+}
+
+.dialpad-section .dialpad-container .dialpad-keys .dialpad-btn {
+	cursor: pointer;
+	border-radius: var(--border-radius-md);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--padding-md) var(--padding-lg);
+	background-color: white;
+}
+
+.dialpad-section .dialpad-container .dialpad-keys .dialpad-btn:hover {
+	background-color: var(--control-bg);
+}
+
+.dialpad-icon {
+	position: absolute;
+	top: 4px;
+	right: 8px;
+	padding: 3px;
+}
+
+.dialpad--pointer {
+	position: absolute;
+	background: white;
+	border-top: 1px solid var(--gray-300);
+	border-right: 1px solid var(--gray-300);
+	width: 10px;
+	height: 10px;
+	z-index: 2001;
+	top: -6px;
+	right: 11px;
+	transform: rotate(315deg);
+}

--- a/twilio_integration/public/js/twilio_call_handler.js
+++ b/twilio_integration/public/js/twilio_call_handler.js
@@ -69,10 +69,9 @@ var onload_script = function() {
 					}
 					popup.setup_dial_icon();
 					popup.setup_dialpad(conn);
-					window.onkeydown = (e) => {
-						const key = String.fromCharCode(e.keyCode);
-						if (["0","1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#", "w"].includes(key)) {
-							e.preventDefault();
+					document.onkeydown = (e) => {
+						const key = e.key;
+						if (conn.status() == 'open' && ["0","1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#", "w"].includes(key)) {
 							conn.sendDigits(key);
 							popup.update_to_number(key);
 						}


### PR DESCRIPTION
To support Interactive Voice Response (IVR), we have added a dial-pad on the Outgoing popup.

The dial-pad button will be visible when you make a call, as shown below
![image](https://user-images.githubusercontent.com/30859809/108022787-3c349500-7047-11eb-8c45-665c9ef44a4c.png)

![image](https://user-images.githubusercontent.com/30859809/108023319-499e4f00-7048-11eb-8b65-a9fa909f1289.png)

You can type numbers from a dial pad or from your keyboard and you can see those numbers on input on the dial pad as shown.

NOTE: You cannot add `*` and `#` from the keyboard you have to use a dial-pad for that.
 