### PR TITLE
fix: added shortcut key to close popup

### DIFF
--- a/twilio_integration/public/js/twilio_call_handler.js
+++ b/twilio_integration/public/js/twilio_call_handler.js
@@ -146,6 +146,13 @@ function get_status_indicator(status) {
 class TwilioCallPopup {
 	constructor(twilio_device) {
 		this.twilio_device = twilio_device;
+		this.attach_shortcuts();
+	}
+
+	attach_shortcuts() {
+		frappe.ui.keys.on(`shift+ctrl+x`, () => {
+			$('.btn-modal-close').click()
+		});
 	}
 
 	hide_hangup_button() {


### PR DESCRIPTION
Added a shortcut key to close the popup.
Shortcut Key:  `shift+ctrl+x`