### PR TITLE
fix: token decode bug

### DIFF
--- a/twilio_integration/twilio_integration/api.py
+++ b/twilio_integration/twilio_integration/api.py
@@ -28,7 +28,7 @@ def generate_access_token():
 
 	token=twilio.generate_voice_access_token(from_number=from_number, identity=frappe.session.user)
 	return {
-		'token': token.decode('utf-8')
+		'token': frappe.safe_decode(token)
 	}
 
 @frappe.whitelist(allow_guest=True)

--- a/twilio_integration/twilio_integration/utils.py
+++ b/twilio_integration/twilio_integration/utils.py
@@ -3,7 +3,7 @@ import frappe
 from frappe.utils import get_url
 
 
-def get_public_url(path: str=None, use_ngrok: bool=True):
+def get_public_url(path: str=None, use_ngrok: bool=False):
 	"""Returns a public accessible url of a site using ngrok.
 	"""
 	if frappe.conf.developer_mode and use_ngrok:


### PR DESCRIPTION
Use safe_decode while decoding the JWT token.

**Here is the traceback**
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/handler.py", line 29, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/handler.py", line 65, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 1174, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-io-bench/apps/twilio_integration/twilio_integration/twilio_integration/api.py", line 31, in generate_access_token
    'token': token.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
