### PR TITLE
fix: Do not allow keyboard integration when dialpad is closed

### DIFF
--- a/twilio_integration/public/js/twilio_call_handler.js
+++ b/twilio_integration/public/js/twilio_call_handler.js
@@ -70,6 +70,7 @@ var onload_script = function() {
 					popup.setup_dial_icon();
 					popup.setup_dialpad(conn);
 					document.onkeydown = (e) => {
+						if (popup.dialog.$wrapper.find('.dialpad-section').is(":hidden")) return;
 						let key = e.key;
 						if (conn.status() == 'open' && ["0","1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "#", "w"].includes(key)) {
 							conn.sendDigits(key);

--- a/twilio_integration/twilio_integration/twilio_handler.py
+++ b/twilio_integration/twilio_integration/twilio_handler.py
@@ -22,7 +22,7 @@ class Twilio:
 		self.application_sid = settings.twiml_sid
 		self.api_key = settings.api_key
 		self.api_secret = settings.get_password("api_secret")
-		self.twilio_client = get_twilio_client()
+		self.twilio_client = self.get_twilio_client()
 
 	@classmethod
 	def connect(self):


### PR DESCRIPTION
When the dial-pad isn't open and we press the number it makes sounds. It's like the dial-pad is functioning even when we don't want to function.