### PR TITLE
fix: Add pyngrok to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # frappe # https://github.com/frappe/frappe is installed during bench-init
 # erpnext # to be installed using bench
 twilio==6.44.2
+pyngrok~=5.1.0


### PR DESCRIPTION
Unsure why #30 was closed but this seems to be required. Pinned PyNgrok to 5.1.* since it seems to work on one of our sites.

Closes #31 