### PR TITLE
fix: get_doctype_list query

### DIFF
--- a/twilio_integration/twilio_integration/doctype/whatsapp_campaign/whatsapp_campaign.py
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_campaign/whatsapp_campaign.py
@@ -62,12 +62,12 @@ class WhatsAppCampaign(Document):
 
 	@frappe.whitelist()
 	def get_doctype_list(self):
-		standard_doctype = frappe.db.sql_list("""SELECT dt.parent FROM `tabDocField` 
-			df INNER JOIN `tabDoctype` dt ON dt.name = dt.parent
+		standard_doctype = frappe.db.sql_list("""SELECT df.parent FROM `tabDocField` 
+			df INNER JOIN `tabDocType` dt ON dt.name = df.parent
 			WHERE df.fieldname='whatsapp_no' AND dt.istable = 0 AND dt.issingle = 0 AND dt.is_tree = 0""")
 		
 		custom_doctype = frappe.db.sql_list("""SELECT dt FROM `tabCustom Field`
-			cf INNER JOIN `tabDoctype` dt ON dt.name = cf.dt
+			cf INNER JOIN `tabDocType` dt ON dt.name = cf.dt
 			WHERE cf.fieldname='whatsapp_no' AND dt.istable = 0 AND dt.issingle = 0 AND dt.is_tree = 0""")
 
 		return standard_doctype + custom_doctype


### PR DESCRIPTION
error on Whatsapp Campaign : 

![Screenshot from 2023-03-18 11-09-14](https://user-images.githubusercontent.com/105269688/226087771-fc5de39f-2900-4918-956a-b695801b721f.png)

Solution Description:

updated the query for get doctype list

(frappe version 14)

